### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Client Setup
 -Open remoteengrave.py with your favorite text editor.  Look at the folowing lines:
 
 ```
-#User set variables
+# User set variables
 remdir = "/home/pi/engravingfiles/"
 address = "raspberrypi.local"
 user = "pi"


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
